### PR TITLE
CodeSniffer workflow: return with exit code 0 even if there are warnings

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -25,4 +25,4 @@ jobs:
           branch: master
 
       - name: Run PHP codesniffer
-        run: phpcs -q  --standard=_test/phpcs.xml --report=checkstyle ${{ steps.dokuwiki-env.outputs.dir }} | cs2pr
+        run: phpcs -q  --standard=_test/phpcs.xml --runtime-set ignore_warnings_on_exit 1 --report=checkstyle ${{ steps.dokuwiki-env.outputs.dir }} | cs2pr


### PR DESCRIPTION
I think it would be useful to handle Code Sniffer warnings less strictly. 

This PR adds a runtime option `ignore_warnings_on_exit` which disregards them when generating the exit code, but does not suppress the output. 

see https://github.com/squizlabs/PHP_CodeSniffer/wiki/Configuration-Options#ignoring-errors-when-generating-the-exit-code