### PR TITLE
Better support for varying PHP support in Plugins

### DIFF
--- a/.github/actions/dokuenv/action.yml
+++ b/.github/actions/dokuenv/action.yml
@@ -1,5 +1,5 @@
-name: 'DokuWiki Plugin Test Action'
-description: 'Run tests for DokuWiki plugins'
+name: 'DokuWiki Environment creator'
+description: 'Install DokuWiki environment for plugin testing'
 inputs:
   branch:
     description: 'The DokuWiki branch to test against'
@@ -12,6 +12,10 @@ outputs:
     description: 'The base name of the extension'
   dir:
     description: 'The full directory name of the extension (lib/plugins/<base> or lib/tpl/<base>)'
+  minphp:
+    description: 'The minimum PHP version required by the extension, if set. Otherwise empty.'
+  maxphp:
+    description: 'The maximum PHP version compatible with the extension, if set. Otherwise empty.'
 runs:
   using: 'node16'
   main: 'index.js'

--- a/.github/actions/dokuwikiUtils.js
+++ b/.github/actions/dokuwikiUtils.js
@@ -1,0 +1,64 @@
+const fs = require('fs');
+
+/**
+ * Get the extension info from the info file and set the type and dir
+ *
+ * @returns {{}}
+ */
+function loadExtensionInfo() {
+    let type = '';
+    let dir = '';
+    let info = '';
+    if (fs.existsSync('plugin.info.txt')) {
+        type = 'plugin';
+        dir = 'plugins';
+        info = 'plugin.info.txt';
+    } else if (fs.existsSync('template.info.txt')) {
+        type = 'template';
+        dir = 'tpl';
+        info = 'template.info.txt';
+    } else {
+        throw new Error('No plugin.info.txt or template.info.txt found!');
+    }
+
+    const config = parsePluginInfo(info);
+    if (!config.base) {
+        throw new Error('No base found in info file!');
+    }
+    const targetDir = `lib/${dir}/${config.base}`;
+    config.type = type;
+    config.dir = targetDir;
+
+    console.log('Extension info:', config);
+    return config;
+}
+
+/**
+ * Parses a plugin.info.txt file into an object
+ *
+ * @param {string} filePath
+ * @returns {{}}
+ */
+function parsePluginInfo(filePath) {
+    const configData = fs.readFileSync(filePath, 'utf8');
+    const lines = configData.split('\n');
+    const configObject = {
+        base: '',
+        minphp: '',
+        maxphp: '',
+    };
+
+    for (const line of lines) {
+        const [key, value] = line.trim().split(/\s+/);
+        if (key && value) {
+            configObject[key] = value;
+        }
+    }
+
+    return configObject;
+}
+
+
+module.exports = {
+    loadExtensionInfo,
+}

--- a/.github/actions/phpmatrix/action.yml
+++ b/.github/actions/phpmatrix/action.yml
@@ -1,0 +1,12 @@
+name: 'Create PHP Test Matrix'
+description: 'Creates the list of PHP versions and DokuWiki branches to test against'
+outputs:
+  stable_matrix:
+    description: 'The matrix for the stable branch'
+  master_matrix:
+    description: 'The matrix for the master branch'
+  minphp:
+    description: 'The minimum PHP version supported'
+runs:
+  using: 'node16'
+  main: 'index.js'

--- a/.github/actions/phpmatrix/index.js
+++ b/.github/actions/phpmatrix/index.js
@@ -1,0 +1,70 @@
+const core = require('@actions/core');
+const dwUtils = require('../dokuwikiUtils');
+
+/**
+ * Convert to string, keeping one decimal place
+ *
+ * @param {Number} num
+ * @returns {string}
+ */
+function toNumberString(num) {
+    if (Number.isInteger(num)) {
+        return num + ".0"
+    } else {
+        return num.toString();
+    }
+}
+
+async function main() {
+    /**
+     * these are the default versions for each branch
+     * @fixme ideally we would load this from the dokuwiki repo
+     */
+    const defaults = {
+        stable: [7.2, 7.3, 7.4, 8.0, 8.1, 8.2],
+        master: [7.4, 8.0, 8.1, 8.2],
+    }
+
+    const matrix = {
+        stable: {
+            'dokuwiki-branch': ['stable'],
+            'php-version': []
+        },
+        master: {
+            'dokuwiki-branch': ['master'],
+            'php-version': []
+        }
+    };
+
+    let minphp = 1000;
+
+    const config = dwUtils.loadExtensionInfo();
+
+    // iterate over versions, only adding those that are in range for the plugin
+    for (const [branch, versions] of Object.entries(defaults)) {
+        for (const php of versions) {
+            if (config.minphp !== '' && parseFloat(config.minphp) > php) {
+                continue;
+            }
+            if (config.maxphp !== '' && parseFloat(config.maxphp) < php) {
+                continue;
+            }
+            matrix[branch]['php-version'].push(toNumberString(php));
+            if (php < minphp) {
+                minphp = php; // remember the lowest version
+            }
+        }
+    }
+
+    // output the matrix
+    core.setOutput('stable_matrix', JSON.stringify(matrix.stable));
+    core.setOutput('master_matrix', JSON.stringify(matrix.master));
+    core.setOutput('minphp', toNumberString(minphp));
+}
+
+
+try {
+    main();
+} catch (error) {
+    core.setFailed(error.message);
+}

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -4,15 +4,26 @@ on:
   workflow_call:
 
 jobs:
+  create-matrix:
+    uses: ./.github/workflows/matrix.yml
+
+  test-master:
+    needs: create-matrix
+    uses: ./.github/workflows/test.yml
+    with:
+      matrix-json: ${{ needs.create-matrix.outputs.master_matrix }}
+
+  test-stable:
+    needs: create-matrix
+    uses: ./.github/workflows/test.yml
+    with:
+      matrix-json: ${{ needs.create-matrix.outputs.stable_matrix }}
+
   code-style:
     uses: ./.github/workflows/cs.yml
-  test-master:
-    uses: ./.github/workflows/test.yml
-    with:
-      matrix-json: '{"php-version": ["7.4", "8.0", "8.1", "8.2"], "dokuwiki-branch": ["master"]}'
-  test-stable:
-    uses: ./.github/workflows/test.yml
-    with:
-      matrix-json: '{"php-version": ["7.2", "7.3", "7.4", "8.0", "8.1", "8.2"], "dokuwiki-branch": ["stable"]}'
+
   auto-fix:
+    needs: create-matrix
     uses: ./.github/workflows/autofix.yml
+    with:
+      rector-php: ${{ needs.create-matrix.outputs.minphp }}

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -2,6 +2,12 @@ name: Automatic Code Style Fixing
 
 on:
   workflow_call:
+    inputs:
+      rector-php:
+        description: 'The PHP version Rector should assume when updating code.'
+        required: true
+        type: string
+        default: '7.2'
 
 permissions:
   contents: write
@@ -27,13 +33,13 @@ jobs:
 
       - name: Create DokuWiki Environment
         id: dokuwiki-env
-        uses: splitbrain/dokuwiki-gh-action@main
+        uses: dokuwiki/github-action/.github/actions/dokuenv@main
         with:
           branch: master
 
-      - name: Run Rector
+      - name: Run Rector (PHP ${{ inputs.rector-php }})
         env:
-          RECTOR_MIN_PHP: 7.2
+          RECTOR_MIN_PHP: ${{ inputs.rector-php }}
         run: rector process --config _test/rector.php --no-diffs ${{ steps.dokuwiki-env.outputs.dir }}
 
       - name: Run PHP CodeSniffer AutoFixing

--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Create DokuWiki Environment
         id: dokuwiki-env
-        uses: splitbrain/dokuwiki-gh-action@main
+        uses: dokuwiki/github-action/.github/actions/dokuenv@main
         with:
           branch: master
 

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -1,0 +1,29 @@
+name: Create PHP Test Matrix
+
+on:
+  workflow_call:
+    outputs:
+      stable_matrix:
+        description: 'The matrix for the stable branch'
+        value: ${{ jobs.create-matrix.outputs.stable_matrix }}
+      master_matrix:
+        description: 'The matrix for the master branch'
+        value: ${{ jobs.create-matrix.outputs.master_matrix }}
+      minphp:
+        description: 'The minimum PHP version supported'
+        value: ${{ jobs.create-matrix.outputs.minphp }}
+
+permissions: { }
+
+jobs:
+  create-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      stable_matrix: ${{ steps.matrix.outputs.stable_matrix }}
+      master_matrix: ${{ steps.matrix.outputs.master_matrix }}
+      minphp: ${{ steps.matrix.outputs.minphp }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - id: matrix
+        uses: dokuwiki/github-action/.github/actions/phpmatrix@main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Create DokuWiki Environment
         id: dokuwiki-env
-        uses: splitbrain/dokuwiki-gh-action@main
+        uses: dokuwiki/github-action/.github/actions/dokuenv@main
         with:
           branch: ${{ matrix.dokuwiki-branch }}
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GitHub Workflows for DokuWiki Extension Development
 
-This repository contains a GitHub Action and reusable workflows for DokuWiki Extension Development.
+This repository contains GitHub Actions and reusable workflows for DokuWiki Extension Development.
 
 By simply reusing the provided standard workflow, extension developers always have an up-to-date toolchain for their development. This includes:
 
@@ -48,7 +48,13 @@ If you're uncomfortable with giving blanket write permissions, you can also manu
 
 If you run into issues with the workflows defined in this repository, please [open a bug report](https://github.com/dokuwiki/github-action/issues). Please be sure to include all necessary log output.
 
-## Devel Details
+## Workflows
+
+Note these infos are mostly for developers of this repository. If you're just using the workflows, you probably don't need to read this.
+
+### matrix.yml
+
+Uses the `phpmatrix` action to create the appropriate strategy matrixes for testing against the master and stable branches. These matrixes are then used in the `test.yml` workflow.
 
 ### test.yml
 
@@ -68,9 +74,23 @@ This workflow runs rector and phpcbf to automatically fix coding style issues, P
 
 It will run on every push on branches `master`, `main` and `devel`.
 
-### GitHub Action
+## Actions
 
-The action defined in this repository will run the following steps:
+### phpmatrix
+
+This action will extract the `minphp` and `maxphp` values from the `plugin.info.txt` and match them with the PHP versions supported by the DokuWiki core. This is done for the `stable` and `master` branches of DokuWiki.
+
+It will then create a JSON string that can be used as input for the `matrix` strategy in GitHub Actions.
+
+The action will set the following outputs:
+
+- `stable_matrix`: The JSON matrix string for the `stable` branch
+- `master_matrix`: The JSON matrix string for the `master` branch
+- `minphp`: The minimum PHP version supported by the extension
+
+### dokuenv
+
+This action will run the following steps:
 
 1. Determine if your extension is a plugin or template
 2. Move your extension to the correct location in a DokuWiki installation (i.e. `lib/plugins` or `lib/tpl`)
@@ -92,5 +112,21 @@ The action is used in the reusable workflows defined in this repository.
 The action can be run locally using node 16 and the following command:
 
 ```
-INPUT_BRANCH=master node ~/path/to/github-action/index.js
+INPUT_BRANCH=master node ~/path/to/dokuenv/index.js
+```
+
+## Development
+
+When improving on the workflows or actions, you should do so in a separate branch. A test plugin can then reference this branch instead of the `main` branch of this repository.
+
+Until [this issue](https://github.com/orgs/community/discussions/66094) is not fixed, all the workflows reference actions by hardcoded repository@branch. These references need to be changed to your devel branch during development. The following command will do this for you:
+
+```
+php fixbranch.php <branch>
+```
+
+Be sure to change back the branch references to `main` before merging your changes back into the `main` branch.
+
+```
+php fixbranch.php main
 ```

--- a/fixbranch.php
+++ b/fixbranch.php
@@ -1,0 +1,23 @@
+#!/usr/bin/env php
+<?php
+
+$argv = $_SERVER['argv'];
+if (count($argv) < 2) {
+    echo "Usage: php fixbranch.php <branchname>\n";
+    exit(1);
+}
+$branch = $argv[1];
+
+$files = array_merge(
+    glob(__DIR__ . '/.github/actions/*/*.yml'),
+    glob(__DIR__ . '/.github/workflows/*.yml')
+);
+
+foreach ($files as $file) {
+    $content = file_get_contents($file);
+    $newcontent = preg_replace('/(uses: dokuwiki\/github-action\/.*@)\w+/', '\1' . $branch, $content);
+    if ($newcontent !== $content) {
+        file_put_contents($file, $newcontent);
+        echo "Updated $file\n";
+    }
+}


### PR DESCRIPTION
Plugins may now define their minimum and maximum PHP requirements in their plugin.info.txt file using the `minphp` and `maxphp` keywords.

The workflows and actions have been extended to take this into account. Tests will only run for the specified range, rector will only refactor PHP constructs up to the minimum supported PHP version.