### PR TITLE
Install composer dependencies for dokuwiki/dokuwiki#4065

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -37,6 +37,11 @@ jobs:
         with:
           branch: master
 
+      - name: Install Composer Dependencies
+        run: |
+          cd _test
+          composer install --no-progress --no-suggest --no-interaction --prefer-dist --optimize-autoloader --no-scripts
+
       - name: Run Rector (PHP ${{ inputs.rector-php }})
         env:
           RECTOR_MIN_PHP: ${{ inputs.rector-php }}

--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -28,5 +28,10 @@ jobs:
         with:
           branch: master
 
+      - name: Install Composer Dependencies
+        run: |
+          cd _test
+          composer install --no-progress --no-suggest --no-interaction --prefer-dist --optimize-autoloader --no-scripts
+
       - name: Run PHP codesniffer
         run: phpcs -q  --standard=_test/phpcs.xml ${{ steps.dokuwiki-env.outputs.dir }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,9 +44,16 @@ jobs:
         with:
           branch: ${{ matrix.dokuwiki-branch }}
 
+      - name: Install Composer Dependencies
+        run: |
+          cd _test
+          composer install --no-progress --no-interaction --prefer-dist --optimize-autoloader --no-scripts
+
       - name: Setup PHPUnit
         run: |
-          php _test/fetchphpunit.php
+          if [ -f _test/fetchphpunit.php ]; then
+            php _test/fetchphpunit.php
+          fi
 
       - name: Check Syntax
         run: |
@@ -55,4 +62,8 @@ jobs:
       - name: Run PHPUnit
         run: |
           cd _test
-          php phpunit.phar --verbose --stderr --group ${{ steps.dokuwiki-env.outputs.type }}_${{ steps.dokuwiki-env.outputs.base }}
+          if [ -f phpunit.phar ]; then
+            php phpunit.phar --verbose --stderr --group ${{ steps.dokuwiki-env.outputs.type }}_${{ steps.dokuwiki-env.outputs.base }}
+          else
+            composer exec -- phpunit --verbose --stderr --group ${{ steps.dokuwiki-env.outputs.type }}_${{ steps.dokuwiki-env.outputs.base }}
+          fi


### PR DESCRIPTION
This does not run the installed tools yet but still relies on the ones installed by the github setup-php action. After the next DokuWiki release the composer dependencies will land in stable and we can start relying on them.

DO NOT MERGE VIA GITHUB - branch needs to be changed on merge!